### PR TITLE
Ignore missing files

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ module.exports = function (givenImagesPath) {
             return callback();
         }
 
-        function inline (inlineExpr, imagePath) {
+        function inline (inlineExpr, quotedPath) {
+            var imagePath = quotedPath.replace(/['"]/g, '');
             try {
                 var fileData = fs.readFileSync(path.join(imagesPath, imagePath));
             }
@@ -44,7 +45,7 @@ module.exports = function (givenImagesPath) {
 
         // check if file.contents is a `Buffer`
         if (file.isBuffer()) {
-            var base64 = String(file.contents).replace(/inline\(['"]?([^\)]+)["']?\)/g, inline);
+            var base64 = String(file.contents).replace(/inline\(([^\)]+)\)/g, inline);
             file.contents = new Buffer(base64);
 
             this.push(file);

--- a/index.js
+++ b/index.js
@@ -35,8 +35,8 @@ module.exports = function (givenImagesPath) {
                 var fileData = fs.readFileSync(path.join(imagesPath, imagePath));
             }
             catch (e) {
-                gutil.log('base64-inline', gutil.colors.red('Referenced file not found: ' + path.join(imagesPath, imagePath)));
-                gutil.log('base64-inline', gutil.colors.red('Leaving it as is.'));
+                gutil.log(gutil.colors.yellow('base64-inline'), 'Referenced file not found: ' + path.join(imagesPath, imagePath));
+                gutil.log(gutil.colors.yellow('base64-inline'), 'Leaving it as is.');
                 return inlineExpr;
             }
 

--- a/index.js
+++ b/index.js
@@ -29,11 +29,17 @@ module.exports = function (givenImagesPath) {
             return callback();
         }
 
-        function inline (image, imagePath) {
+        function inline (inlineExpr, imagePath) {
+            try {
+                var fileData = fs.readFileSync(path.join(imagesPath, imagePath));
+            }
+            catch (e) {
+                return inlineExpr;
+            }
+
+            var fileBase64 = new Buffer(fileData).toString('base64');
             var fileMime = mime.lookup(imagePath);
-            var prefix = 'url(data:' + fileMime  + ';base64,';
-            var fileData = fs.readFileSync(path.join(imagesPath, imagePath));
-            return prefix + new Buffer(fileData).toString('base64') + ')';
+            return 'url(data:' + fileMime  + ';base64,' + fileBase64 + ')';
         }
 
         // check if file.contents is a `Buffer`

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (givenImagesPath) {
 
         // check if file.contents is a `Buffer`
         if (file.isBuffer()) {
-            var base64 = String(file.contents).replace(/inline\('(.+)'\)/g, inline);
+            var base64 = String(file.contents).replace(/inline\(['"]?([^\)]+)["']?\)/g, inline);
             file.contents = new Buffer(base64);
 
             this.push(file);

--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ module.exports = function (givenImagesPath) {
                 var fileData = fs.readFileSync(path.join(imagesPath, imagePath));
             }
             catch (e) {
+                gutil.log('base64-inline', gutil.colors.red('Referenced file not found: ' + path.join(imagesPath, imagePath)));
+                gutil.log('base64-inline', gutil.colors.red('Leaving it as is.'));
                 return inlineExpr;
             }
 


### PR DESCRIPTION
Hello!

Thank you for your plugin.

I'm working now on refactoring rails & compass project from sprockets to gulp. It's large, and gulp-base64-inline was very helpful.

While experimenting, I've found that it is useful to ignore errors, raised during inlining when referenced file not found.

So we can chain base64-inline calls through multiple dirs:

``` javascript
gulp.src('./stylesheets')
    .pipe(base64Inline(path.resolve('./images')))
    .pipe(base64Inline(path.resolve('./fonts')))
```

Also in 9e74c11 I tried to fix RegExp for parsing inline instructions, to accept `inline("foo.png")` as well as `inline('foo.png')`, and even `inline(foo.png)`.
